### PR TITLE
Set pip version explicitly

### DIFF
--- a/python/init.sls
+++ b/python/init.sls
@@ -4,7 +4,11 @@
 # This command will run if pip is broken and install a version of pip that works!
 pip-fixer:
   cmd.run:
+{% if python.pip_version is defined %}
+    - name: "easy_install -U pip=={{ python.pip_version }} 'requests[security]'"
+{% else %}
     - name: "easy_install -U pip 'requests[security]'"
+{% endif %}
     # Test that the current installed version of pip works when requests is
     # loaded. The python-pip shipped with ubuntu 14.04 doesn't work.
     - unless: >
@@ -18,7 +22,7 @@ pip-fixer:
 
 install-virtualenv:
   pip.installed:
-{% if python.virtualenv_version  %}
+{% if python.virtualenv_version is defined %}
     - name: virtualenv=={{ python.virtualenv_version }}
 {% else %}
     - name: virtualenv

--- a/python/map.jinja
+++ b/python/map.jinja
@@ -1,5 +1,5 @@
 {% set python = salt['grains.filter_by']({
   'Ubuntu': {
-    'virtualenv_version': None,
+    'pip_version': 8.1.1,
   }
 }, merge=salt['pillar.get']('python:lookup'), default='Ubuntu') %}


### PR DESCRIPTION
Due to a bug in salt, pip version 8.1.2 breaks the salt state. This
change set the pip version explicitly to 8.1.1.
See https://github.com/saltstack/salt/issues/33163 for a description.
