### PR TITLE
(WIP) Always install a local version of pip

### DIFF
--- a/python/init.sls
+++ b/python/init.sls
@@ -1,18 +1,9 @@
 {% from 'python/map.jinja' import python with context %}
 
-# There is a bug in the ubuntu pip package https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1306991
-# This command will run if pip is broken and install a version of pip that works!
+# This command will install a local version of pip
 pip-fixer:
   cmd.run:
-{% if python.pip_version is defined %}
     - name: "easy_install -U pip=={{ python.pip_version }} 'requests[security]'"
-{% else %}
-    - name: "easy_install -U pip 'requests[security]'"
-{% endif %}
-    # Test that the current installed version of pip works when requests is loaded
-    # Test that the installed version of pip has a project_name variable, Salt <=2015.8.5 is incompatible with Pip v8.1.2
-    - unless:
-       - python -c "import pip; pip.req.InstallRequirement.from_line('somereq').req.project_name; __requires__=['pip>=7.1.0', 'requests>=2.7.0']; import pkg_resources"
     - require_in:
       - pip.*
     - require:


### PR DESCRIPTION
SaltStack requires a system-wide version of pip, but some of the
packages wont work without a local version installed too.
