### PR TITLE
Pin version of setuptools

### DIFF
--- a/python/init.sls
+++ b/python/init.sls
@@ -3,7 +3,7 @@
 # This command will install a local version of pip
 pip-fixer:
   cmd.run:
-    - name: "easy_install -U pip=={{ python.pip_version }} 'requests[security]==2.12.1'"
+    - name: "easy_install -U pip=={{ python.pip_version }} setuptools=={{ python.setuptools_version }} 'requests[security]=={{ python.requests_version }}'"
     - require_in:
       - pip.*
     - require:

--- a/python/map.jinja
+++ b/python/map.jinja
@@ -1,15 +1,21 @@
 {% set python = salt['grains.filter_by']({
 
     'Ubuntu-12.04': {
-            'pip_version': '8.1.1'
+        'pip_version': '8.1.1',
+        'requests_version': '2.11.1',
+        'setuptools_version': '30.1.0'
     },
 
     'Ubuntu-14.04': {
-        'pip_version': '8.1.1'
+        'pip_version': '8.1.1',
+        'requests_version': '2.11.1',
+        'setuptools_version': '30.1.0'
     },
 
     'Unknown': {
-        'pip_version': '8.1.1'
+        'pip_version': '8.1.1',
+        'requests_version': '2.11.1',
+        'setuptools_version': '30.1.0'
     }
 
 }, grain='osfinger', merge=salt['pillar.get']('python',{}), default='Unknown') %}


### PR DESCRIPTION
This change allows the pinning of the version of setuptools in addition
to the currently pinned pip and requests versions. This allows
explicitly avoiding a current break of compatibility with the > 30.1.0
series of setuptools.